### PR TITLE
FIXED: atom indexing segfault with signal 11 on Mac OS X

### DIFF
--- a/atom.c
+++ b/atom.c
@@ -55,7 +55,7 @@
 		 *******************************/
 
 int
-get_atom_text(atom_t atom, text *txt)
+fetch_atom_text(atom_t atom, text *txt)
 { if ( (txt->a = (const charA*)PL_atom_nchars(atom, &txt->length)) )
   { txt->w = NULL;
     return TRUE;
@@ -80,7 +80,7 @@ fill_atom_info(atom_info *info)
 { if ( !info->resolved )
   { info->resolved = TRUE;
 
-    if ( !(info->rc=get_atom_text(info->handle, &info->text)) )
+    if ( !(info->rc=fetch_atom_text(info->handle, &info->text)) )
     { info->text.a = NULL;
       info->text.w = NULL;
     }
@@ -143,7 +143,7 @@ cmp_atom_info(atom_info *info, atom_t a2)
     return 0;
 
   if ( !fill_atom_info(info) ||
-       !get_atom_text(a2, &t2) )
+       !fetch_atom_text(a2, &t2) )
   { goto cmphandles;			/* non-text atoms? */
   }
 
@@ -299,7 +299,7 @@ atom_t
 first_atom(atom_t a, int match)
 { text t;
 
-  if ( !get_atom_text(a, &t) )
+  if ( !fetch_atom_text(a, &t) )
   { return (atom_t)0;			/* not a textual atom */
   } else
   { size_t len = t.length;
@@ -499,8 +499,8 @@ int
 match_atoms(int how, atom_t search, atom_t label)
 { text l, f;
 
-  if ( !get_atom_text(label, &l) ||
-       !get_atom_text(search, &f) )
+  if ( !fetch_atom_text(label, &l) ||
+       !fetch_atom_text(search, &f) )
     return FALSE;			/* error? */
 
   return match_text(how, &f, &l);
@@ -713,8 +713,8 @@ atom_lang_matches(atom_t lang, atom_t pattern)
   if ( pattern == ATOM_star )		/* Everything matches "*" */
     return TRUE;
 
-  if ( !get_atom_text(lang, &s.l) ||
-       !get_atom_text(pattern, &s.p) )
+  if ( !fetch_atom_text(lang, &s.l) ||
+       !fetch_atom_text(pattern, &s.p) )
     return FALSE;			/* exception? */
 
   s.il=0; s.ip=0;

--- a/atom.h
+++ b/atom.h
@@ -101,6 +101,6 @@ COMMON(int)		match_text(int how, text *search, text *label);
 COMMON(unsigned int)	atom_hash_case(atom_t a);
 COMMON(int)		atom_lang_matches(atom_t lang, atom_t pattern);
 COMMON(int)		fill_atom_info(atom_info *info);
-COMMON(int)		get_atom_text(atom_t atom, text *txt);
+COMMON(int)		fetch_atom_text(atom_t atom, text *txt);
 
 #endif /*ATOM_H_INCLUDED*/

--- a/xsd.c
+++ b/xsd.c
@@ -129,7 +129,7 @@ cmp_xsd_info(xsd_primary type1, atom_info *v1,
 
   if ( fill_atom_info(v1) &&
        v1->text.a &&
-       get_atom_text(v2, &t2) &&
+       fetch_atom_text(v2, &t2) &&
        t2.a )
   { return xsd_compare_numeric(type1, v1->text.a, type2, t2.a);
   } else


### PR DESCRIPTION
As discussed per thread:
https://github.com/SWI-Prolog/packages-semweb/issues/22

Naming conflict and unsuitable detection of Apple LLVM and
clang's support for visibility attribute results wrong function
call at runtime when certain optimisation flags are used.

This fix changes the name of the function to avoid naming
conflict on platform that doesn't support proper isolation.