### PR TITLE
FIXED: check visibility attribute support of compiler

### DIFF
--- a/configure.in
+++ b/configure.in
@@ -10,20 +10,18 @@ AC_CHECK_SIZEOF(long)
 AC_CHECK_SIZEOF(void*)
 
 dnl This fragment is from the glibc configure script
+dnl with modification to fit different platforms
 
 if test "$GCC" = "yes"; then
   AC_CACHE_CHECK(whether __attribute__((visibility())) is supported,
                  libc_cv_visibility_attribute,
                  [cat > conftest.c <<EOF
                   int foo __attribute__ ((visibility ("hidden"))) = 1;
-                  int bar __attribute__ ((visibility ("protected"))) = 1;
 EOF
                   libc_cv_visibility_attribute=no
                   if ${CC-cc} -Werror -S conftest.c -o conftest.s >/dev/null 2>&1; then
-                    if grep '\.hidden.*foo' conftest.s >/dev/null; then
-                      if grep '\.protected.*bar' conftest.s >/dev/null; then
-                        libc_cv_visibility_attribute=yes
-                      fi
+                    if grep -E "\.(private_extern|hidden).*foo" conftest.s >/dev/null; then
+                      libc_cv_visibility_attribute=yes
                     fi
                   fi
                   rm -f conftest.[cs]


### PR DESCRIPTION
Mac OS X does not support `protected` visibility, plus it doesn't
generate `hidden` in the assembly file, but `private_extern`.