### PR TITLE
Makefile.in: fix turtle.so object file deps

### DIFF
--- a/Makefile.in
+++ b/Makefile.in
@@ -34,7 +34,7 @@ all:		$(TARGETS)
 
 rdf_db.@SO@:	$(RDFDBOBJ)
 		$(LD) $(LDSOFLAGS) -o $@ $(RDFDBOBJ) $(LIBS) $(LIBPLSO)
-turtle.@SO@:	turtle.o
+turtle.@SO@:	turtle.o murmur.o
 		$(LD) $(LDSOFLAGS) -o $@ turtle.o murmur.o $(LIBS) $(LIBPLSO)
 ntriples.@SO@:	ntriples.o
 		$(LD) $(LDSOFLAGS) -o $@ ntriples.o $(LIBS) $(LIBPLSO)


### PR DESCRIPTION
turtle.so target was missing the dependency on murmur.o, which caused a race condition on parallel builds.