### PR TITLE
fixed exception in rdfs_container/2

### DIFF
--- a/rdf11_containers.pl
+++ b/rdf11_containers.pl
@@ -208,7 +208,7 @@ rdfs_assert_members([H|T], N1, Resource, G) :-
 rdfs_container(Container, List) :-
     rdf_is_subject(Container),
     !,
-    findall(N-Elem, rdfs_member(Container, N, Elem), Pairs),
+    findall(N-Elem, rdfs_member0(Container, N, Elem), Pairs),
     keysort(Pairs, Sorted),
     group_pairs_by_key(Sorted, GroupedPairs),
     pairs_values(GroupedPairs, Groups),


### PR DESCRIPTION
I seems that during renaming of `rdfs_member` to `rdfs_member0`, this particular usage hasn't been updated, which causes exception during evaluation of `rdfs_container/2`.