### PR TITLE
Removed redundant check causing severe performance penalty on big graphs

### DIFF
--- a/rdf_db.pl
+++ b/rdf_db.pl
@@ -2233,14 +2233,15 @@ rdf_do_save(Out, Options0) :-
 
 rdf_subject(Subject, Options) :-
     graph(Options, DB),
-    var(DB),
-    !,
-    rdf_subject(Subject).
-rdf_subject(Subject, Options) :-
-    graph(Options, DB),
-    (   rdf(Subject, _, _, DB:_)
-    ->  true
+    (   var(DB)
+    ->  rdf_subject(Subject)
+    ;   rdf_subject_db(Subject, DB)
     ).
+
+rdf_subject_db(Subject, DB) :-
+    findall(S, rdf(S, _, _, DB:_), List),
+    sort(List, Subjects),
+    member(Subject, Subjects).
 
 graph(Options0, DB) :-
     strip_module(Options0, _, Options),

--- a/rdf_db.pl
+++ b/rdf_db.pl
@@ -2238,7 +2238,6 @@ rdf_subject(Subject, Options) :-
     rdf_subject(Subject).
 rdf_subject(Subject, Options) :-
     graph(Options, DB),
-    rdf_subject(Subject),
     (   rdf(Subject, _, _, DB:_)
     ->  true
     ).


### PR DESCRIPTION
I don't see the reason why we need to check if `Subject` is subject using `rdf_subject(Subject)` globally, when the next check does the same thing but within given graph boundaries. Serializing even small graphs to XML when the size of DB is big becomes very slow here.