### PR TITLE
FIXED: Meta-predicate declaration for rdf_save_canonical_trig/2.

### DIFF
--- a/rdf_turtle_write.pl
+++ b/rdf_turtle_write.pl
@@ -151,6 +151,7 @@ has the following properties:
 :- meta_predicate
     rdf_save_turtle(+, :),
     rdf_save_canonical_turtle(+, :),
+    rdf_save_canonical_trig(+, :),
     rdf_save_trig(+, :).
 
 %!  rdf_save_turtle(+Out, :Options) is det.


### PR DESCRIPTION
Without this fix argument `Module:Options` does not match calls that give a plain list (with no module prefix).
