### PR TITLE
FIXED: Make explicit that UTF-8 encoding is used.

### DIFF
--- a/rdf11_containers.pl
+++ b/rdf11_containers.pl
@@ -1,3 +1,4 @@
+:- encoding(utf8).
 /*  Part of SWI-Prolog
 
     Author:        Jan Wielemaker and Wouter Beek


### PR DESCRIPTION
Without this directive, non-UTF8 environemnts may give a warning.