### PR TITLE
Fix to accept strings in save_attribute_value/3

### DIFF
--- a/rdf_db.pl
+++ b/rdf_db.pl
@@ -2966,7 +2966,9 @@ save_body_literal(DOM,
                       NameText, BaseURI, Out, Indent, Options).
 
 save_attribute_value(Value, Out, _) :-  % strings
-    atom(Value),
+    (	atom(Value)
+	;	string(Value)
+	),
     !,
     stream_property(Out, encoding(Encoding)),
     xml_quote_cdata(Value, QVal, Encoding),


### PR DESCRIPTION
When serializing `xsd:dateTime` property to RDF/XML an exception is thrown:
```
Reason = exception(error(save_attribute_value(2019-08-27T17:23:02.728438-02:00),_9104))
ERROR: Unknown error term: save_attribute_value("2019-08-27T17:23:02.728438-02:00")
...
```

This is due to the fact that `save_attribute_value/3` accepts only atom as a string value type. However, `rdf_db:rdf` returns such literals as `type(xsd:dateTime, "value")` where `"value"` is a string.