### PR TITLE
Fixes #92

### DIFF
--- a/sparql_client.pl
+++ b/sparql_client.pl
@@ -155,7 +155,7 @@ sparql_query(Query, Row, Options) :-
               [ header(content_type, ContentType),
                 status_code(Status)
               | HTTPOptions
-              ]),
+              ]), !,
     plain_content_type(ContentType, CleanType),
     read_reply(Status, CleanType, In, VarNames, Row).
 


### PR DESCRIPTION
When using authorization, a choice point is left in http_open that will remove the authorization and send the request again. This results in a 401 authorization failure once the results for the query have been consumed. The cut prevents this back-tracking once the response has been received.