### PR TITLE
FIXED: Wrong argument type for PL_*_external()

### DIFF
--- a/rdf_db.h
+++ b/rdf_db.h
@@ -276,7 +276,7 @@ typedef struct literal
     int64_t	integer;
     double	real;
     struct
-    { record_t  record;
+    { char *    record;
       size_t	len;
     } term;				/* external record */
   } value;


### PR DESCRIPTION
The SWI-Prolog.h external record functions use `char *` for the type of the external record data, but rdf_db is storing it and passing it as a `record_t`. Which went unnoticed when `record_t` was just a typedef for `void *`, but now causes (non-fatal) warnings during compilation, with the new opaque-struct-typed API header.