### PR TITLE
Fixes #103 rdf_flush_journals/1 flushes journals correctly

### DIFF
--- a/rdf_persistency.pl
+++ b/rdf_persistency.pl
@@ -375,7 +375,7 @@ rdf_flush_journal(Graph, Options) :-
     (   \+ exists_file(File)
     ->  true
     ;   memberchk(min_size(KB), Options),
-        size_file(JournalFile, Size),
+        size_file(File, Size),
         Size / 1024 < KB
     ->  true
     ;   create_db(Graph)


### PR DESCRIPTION
Changed the use of `size_file/2` in `rdf_flush_journal/2` to reference the
variable File (instead of JournalFile) which represents the full path of
the journal file to be flushed.