### PR TITLE
FIXED: rdf_literal/1 should not succeed on IRIs in object position

### DIFF
--- a/rdf11.pl
+++ b/rdf11.pl
@@ -1554,6 +1554,10 @@ gen_term(O) :-                          % performs double conversion!
 rdf_literal(Term) :-
     ground(Term),
     !,
+    (   boolean(Term)
+    ;   \+ atom(Term)
+    ),
+    !,
     pre_ground_object(Term, Object),
     (rdf_db:rdf(_,_,Object)->true).
 rdf_literal(Term) :-

--- a/test_rdf11.pl
+++ b/test_rdf11.pl
@@ -159,6 +159,8 @@ test(type, set(Literal == [ 42^^xsd:integer,
                             true^^xsd:boolean,
                             "hello"^^xsd:string])) :-
     rdf_literal(Literal).
+test(type, fail) :-
+    rdf_literal(c).
 % deterministic tests
 test(enum_det) :- rdf_name(true).
 test(enum_det) :- rdf_name(a).


### PR DESCRIPTION
I noticed that `rdf_literal/1` uses `pre_ground_object/2` internally that succeeds on ground atom terms. However, `rdf_literal/1` should only succeed on ground _literals_ (booleans is exception) and not IRIs.