### PR TITLE
Avoid uninitialized olds in read_blank_note_property_list

### DIFF
--- a/turtle.c
+++ b/turtle.c
@@ -1965,14 +1965,14 @@ read_collection(turtle_state *ts)
 
 static resource *
 read_blank_node_property_list(turtle_state *ts)
-{ resource *olds, *bnode, *oldp = NULL;
+{ resource *olds = NULL, *bnode, *oldp = NULL;     // initialize olds
   int rc;
 
   rc = ( set_anon_subject(ts, &olds) &&
 	 set_predicate(ts, NULL, &oldp) &&
 	 read_predicate_object_list(ts, "]")
        );
-  set_subject(ts, olds, &bnode);
+  set_subject(ts, olds, &bnode);                   // alternatively: if(rc) set_subject(...);
   set_predicate(ts, oldp, NULL);
 
   if ( rc && ts->current_char == ']' && next(ts) )


### PR DESCRIPTION
I get a warning that olds is maybe uninitialized in this function.

I don't fully understand the code, but if set_anon_subject fails (out of memory), then olds is indeed uninitialized. Either initialize olds = NULL, or check rc before set_subject. I am unsure about both alternatives, please see the comments in the suggested fix. 