### PR TITLE
rdf_murmer_hash def and decl type agreement

### DIFF
--- a/murmur.c
+++ b/murmur.c
@@ -67,7 +67,7 @@ rdf_murmer_hash(const void * key, size_t len, unsigned int seed)
 #define MIX(h,k,m) { k *= m; k ^= k >> r; k *= m; h *= m; h ^= k; }
 
 unsigned int
-rdf_murmer_hash(const void *key, int len, unsigned int seed)
+rdf_murmer_hash(const void *key, size_t len, unsigned int seed)
 { const unsigned int m = 0x5bd1e995;
   const int r = 24;
   const unsigned char * data = (const unsigned char *)key;


### PR DESCRIPTION
The `rdf_murmer_hash` declaration in murmur.h and the big endian definition in murmur.c both have `size_t` as the type of the second argument, `len`.  Make the little endian definition match the declaration and the big endian definition.
